### PR TITLE
ONEUI-650: Changing default port for OneUI Server

### DIFF
--- a/docker-compose.common-tmpl.yml
+++ b/docker-compose.common-tmpl.yml
@@ -51,7 +51,7 @@ services:
     networks:
       - fusion
     ports:
-      - ${ONEUI_SERVER_PORT}:8080
+      - ${ONEUI_SERVER_PORT}:8081
     environment:
       - FUSION_SERVER_HOSTNAMES=http://fusion-server-${ZONE_A_NAME}:${ZONE_A_SERVER_PORT},http://fusion-server-${ZONE_B_NAME}:${ZONE_B_SERVER_PORT}
     env_file:


### PR DESCRIPTION
Changing default port for OneUI Server to 8081 to not conflict with Ambari.