### PR TITLE
LMP-104

### DIFF
--- a/config_files/krb5.conf
+++ b/config_files/krb5.conf
@@ -1,0 +1,27 @@
+# Configuration snippets may be placed in this directory as well
+includedir /etc/krb5.conf.d/
+
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ dns_lookup_realm = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+ rdns = false
+ pkinit_anchors = /etc/pki/tls/certs/ca-bundle.crt
+# default_realm = EXAMPLE.COM
+ default_ccache_name = KEYRING:persistent:%{uid}
+
+[realms]
+# EXAMPLE.COM = {
+#  kdc = kerberos.example.com
+#  admin_server = kerberos.example.com
+# }
+
+[domain_realm]
+# .example.com = EXAMPLE.COM
+# example.com = EXAMPLE.COM

--- a/docker-compose.zone-tmpl-cdh.yml
+++ b/docker-compose.zone-tmpl-cdh.yml
@@ -53,7 +53,7 @@ services:
       - logging-npx-${ZONE_NAME}:/var/log/fusion
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -76,7 +76,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -98,7 +98,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-checkpoint:/opt/wandisco/fusion/server/checkpoint
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -124,7 +124,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-dcone:/opt/wandisco/fusion/server/dcone
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-cdh.yml
+++ b/docker-compose.zone-tmpl-cdh.yml
@@ -53,7 +53,7 @@ services:
       - logging-npx-${ZONE_NAME}:/var/log/fusion
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -76,7 +76,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -98,7 +98,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-checkpoint:/opt/wandisco/fusion/server/checkpoint
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -124,7 +124,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-dcone:/opt/wandisco/fusion/server/dcone
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-cdh.yml
+++ b/docker-compose.zone-tmpl-cdh.yml
@@ -53,6 +53,7 @@ services:
       - logging-npx-${ZONE_NAME}:/var/log/fusion
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -75,6 +76,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -96,6 +98,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-checkpoint:/opt/wandisco/fusion/server/checkpoint
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -121,6 +124,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-dcone:/opt/wandisco/fusion/server/dcone
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-cdh.yml
+++ b/docker-compose.zone-tmpl-cdh.yml
@@ -54,6 +54,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -77,6 +78,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -99,6 +101,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -125,6 +128,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-hdp.yml
+++ b/docker-compose.zone-tmpl-hdp.yml
@@ -53,7 +53,7 @@ services:
       - logging-npx-${ZONE_NAME}:/var/log/fusion
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -75,7 +75,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/{PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -96,7 +96,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-checkpoint:/opt/wandisco/fusion/server/checkpoint
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -119,7 +119,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-dcone:/opt/wandisco/fusion/server/dcone
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
+      - ./config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-hdp.yml
+++ b/docker-compose.zone-tmpl-hdp.yml
@@ -53,7 +53,7 @@ services:
       - logging-npx-${ZONE_NAME}:/var/log/fusion
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -75,7 +75,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/{PWD}/config_files/krb5.conf:/etc/krb5.conf
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -96,7 +96,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-checkpoint:/opt/wandisco/fusion/server/checkpoint
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -119,7 +119,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-dcone:/opt/wandisco/fusion/server/dcone
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
-      - config_files/krb5.conf:/etc/krb5.conf
+      - {PWD}/config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-hdp.yml
+++ b/docker-compose.zone-tmpl-hdp.yml
@@ -53,6 +53,7 @@ services:
       - logging-npx-${ZONE_NAME}:/var/log/fusion
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -74,6 +75,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -94,6 +96,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-checkpoint:/opt/wandisco/fusion/server/checkpoint
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -116,6 +119,7 @@ services:
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-server-dcone:/opt/wandisco/fusion/server/dcone
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
+      - config_files/krb5.conf:/etc/krb5.conf
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/docker-compose.zone-tmpl-hdp.yml
+++ b/docker-compose.zone-tmpl-hdp.yml
@@ -54,6 +54,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
 
   # Fusion UI Server
   fusion-ui-server-${ZONE_NAME}:
@@ -76,6 +77,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
       ${LICENSE_FILE_PATH}
 
   # Fusion IHC Server
@@ -97,6 +99,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
       - fusion-${ZONE_NAME}-restart:/restart
       ${LICENSE_FILE_PATH}
 
@@ -120,6 +123,7 @@ services:
       - fusion-${ZONE_NAME}-etc-wandisco:/etc/wandisco
       - fusion-${ZONE_NAME}-etc-hadoop:/etc/hadoop
       - ./config_files/krb5.conf:/etc/krb5.conf
+      - ./keytabs:/etc/security/keytabs
       - fusion-${ZONE_NAME}-restart:/restart
       - fusion-${ZONE_NAME}-opt-wandisco-fusion-ui-server-properties:/opt/wandisco/fusion-ui-server/properties
       ${LICENSE_FILE_PATH}

--- a/keytabs/readme
+++ b/keytabs/readme
@@ -1,0 +1,5 @@
+This directory can be used to store Kerberos keytabs that will be mapped to the following directory on HDP or CDH containers:
+
+/etc/security/keytabs
+
+Copy your keytab(s) into this directory and run a "docker-compose restart" to make the keytab(s) available in the containers.


### PR DESCRIPTION
Three commits in total. (EDIT: additional one mentioned in 2nd comment)

This change creates a config_files directory and stores an example krb5.conf file inside. Changes to the CDH and HDP docker compose yamls will now persist this file to the containers. Any changes to the config_files/krb5.conf will persist to Fusion containers in /etc/krb5.conf after a docker-compose restart.

The idea being a user can simply replace this file with their own krb5.conf (or manually edit if they desire).