### PR TITLE
DAP-211 Remove ADLS Gen1/Gen2 questions from setup_env

### DIFF
--- a/zone-adls1.conf
+++ b/zone-adls1.conf
@@ -17,12 +17,13 @@ save_var ADLS_GEN "adls1" "$SAVE_ENV"
 
 validate_hdi_version "$HDI_VERSION"
 update_var HDI_VERSION "Enter the HDI version for $ZONE_NAME" "" validate_hdi_version
-update_var FS_ADLS_HOME_HOSTNAME "Enter the ADLS home hostname for $ZONE_NAME" "example.westeurope.azuredatalakestore.net" validate_hostname
-update_var FS_ADLS_HOME_MOUNTPOINT "Enter the ADLS home mountpoint for $ZONE_NAME" "/" validate_not_empty
-update_var FS_ADL_HANDSHAKE_USER "Enter the ADL handshake user for $ZONE_NAME" "" validate_not_empty
-update_var FS_ADL_OAUTH2_CREDENTIAL "Enter the ADL OAUTH2 Credential for $ZONE_NAME" "" validate_not_empty
-update_var FS_ADL_OAUTH2_REFRESH_URL "Enter the ADL OAUTH2 Refresh URL for $ZONE_NAME" "https://login.microsoftonline.com/example/oauth2/token" validate_not_example
-update_var FS_ADL_OAUTH2_CLIENT_ID "Enter the ADL OAUTH2 Client ID for $ZONE_NAME" "" validate_not_empty
+
+save_var FS_ADLS_HOME_HOSTNAME "example.westeurope.azuredatalakestore.net" "$SAVE_ENV"
+save_var FS_ADLS_HOME_MOUNTPOINT "/" "$SAVE_ENV"
+save_var FS_ADL_HANDSHAKE_USER "" "$SAVE_ENV"
+save_var FS_ADL_OAUTH2_CREDENTIAL "" "$SAVE_ENV"
+save_var FS_ADL_OAUTH2_REFRESH_URL "https://login.microsoftonline.com/example/oauth2/token" "$SAVE_ENV"
+save_var FS_ADL_OAUTH2_CLIENT_ID "" "$SAVE_ENV"
 
 save_var PLATFORM "hcfs-azure-hdi-${HDI_VERSION}" "$SAVE_ENV"
 

--- a/zone-adls2.conf
+++ b/zone-adls2.conf
@@ -18,11 +18,11 @@ save_var ADLS_GEN "adls2" "$SAVE_ENV"
 validate_hdi_version "$HDI_VERSION"
 update_var HDI_VERSION "Enter the HDI version for $ZONE_NAME" "" validate_hdi_version
 
-update_var AZURE_STORAGE_ACCT_NAME "Enter the Azure storage account name for $ZONE_NAME" "" validate_not_empty
-update_var AZURE_STORAGE_CONTAINER "Enter the Azure storage container for $ZONE_NAME" "" validate_not_empty
-update_var FS_AZURE_ACCOUNT_KEY "Enter the Azure account key for $ZONE_NAME" "" validate_not_empty
-update_var FS_DEFAULT_FS "Enter the default FS for $ZONE_NAME" "abfss://$AZURE_STORAGE_CONTAINER@$AZURE_STORAGE_ACCT_NAME.dfs.core.windows.net/" validate_not_example
-update_var FS_FUSION_UNDERLYING_FS "Enter the underlying FS for $ZONE_NAME" "abfs://$AZURE_STORAGE_CONTAINER@$AZURE_STORAGE_ACCT_NAME.dfs.core.windows.net/" validate_not_example
+save_var AZURE_STORAGE_ACCT_NAME "" "$SAVE_ENV"
+save_var AZURE_STORAGE_CONTAINER "" "$SAVE_ENV"
+save_var FS_AZURE_ACCOUNT_KEY "" "$SAVE_ENV"
+save_var FS_DEFAULT_FS "abfss://$AZURE_STORAGE_CONTAINER@$AZURE_STORAGE_ACCT_NAME.dfs.core.windows.net/" "$SAVE_ENV"
+save_var FS_FUSION_UNDERLYING_FS "abfs://$AZURE_STORAGE_CONTAINER@$AZURE_STORAGE_ACCT_NAME.dfs.core.windows.net/" "$SAVE_ENV"
 
 save_var PLATFORM "hcfs-azure-hdi-${HDI_VERSION}" "$SAVE_ENV"
 


### PR DESCRIPTION
Removed only ADLS Gen1/Gen2 credentials questions as written in issue.
Desired behaviour works fine (configuration through OneUI, legacy UI restarts and it’s possible to browse storage on rule creation there).