### PR TITLE
Merge pull request #283 from WANdisco/beta/oneui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test.tpl
 !docker-compose.monitoring-tmpl.yml
 !docker-compose.sandbox-hdp-vanilla.yml
 !docker-compose.sandbox-hdp-vanilla-extended.yml
+!docker-compose.sandbox-cdh-vanilla.yml
 !docker-compose.livedata-migrator.yml
 [._]*.sw[a-p]
 *.sh_history

--- a/common.conf
+++ b/common.conf
@@ -11,27 +11,29 @@
 # Common settings
 
 update_var COMPOSE_PROJECT_NAME "Enter the compose project name" "fusion" validate_not_empty
-
 update_var DOCKER_HOSTNAME "Enter the docker hostname" "${HOSTNAME:-$(hostname)}" validate_hostname
 
-update_var ZONE_A_UI_PORT "Enter the HTTP port for the first zone" "8083" validate_number
-update_var ZONE_A_SERVER_PORT "Enter the REST API port for the first zone" "8082" validate_number
+if [[ "$ZONE_A_TYPE" != "hdp-vanilla" && "$ZONE_A_TYPE" != "cdh-vanilla" ]]; then
+  update_var ZONE_A_UI_PORT "Enter the HTTP port for the first zone" "8083" validate_number
+  update_var ZONE_A_SERVER_PORT "Enter the REST API port for the first zone" "8082" validate_number
+  : "${ZONE_A_NODE_ID:=$(./utils/uuid-gen.py)}"
+  save_var ZONE_A_NODE_ID "${ZONE_A_NODE_ID}" "$SAVE_ENV"
+fi
 
-update_var ZONE_B_UI_PORT "Enter the HTTP port for the second zone" "8583" validate_number
-update_var ZONE_B_SERVER_PORT "Enter the REST API port for the second zone" "8582" validate_number
+if [ "$ZONE_B_TYPE" != NONE ]; then
+  update_var ZONE_B_UI_PORT "Enter the HTTP port for the second zone" "8583" validate_number
+  update_var ZONE_B_SERVER_PORT "Enter the REST API port for the second zone" "8582" validate_number
+  : "${ZONE_B_NODE_ID:=$(./utils/uuid-gen.py)}"
+  save_var ZONE_B_NODE_ID "${ZONE_B_NODE_ID}" "$SAVE_ENV"
+fi
 
 update_var LIVEDATA_UI_PORT "Enter the LiveData UI external http port" "8081" validate_number
-
-: "${ZONE_A_NODE_ID:=$(./utils/uuid-gen.py)}"
-: "${ZONE_B_NODE_ID:=$(./utils/uuid-gen.py)}"
-save_var ZONE_A_NODE_ID "${ZONE_A_NODE_ID}" "$SAVE_ENV"
-save_var ZONE_B_NODE_ID "${ZONE_B_NODE_ID}" "$SAVE_ENV"
 
 # save versions
 save_var FUSION_BASE_VERSION           "2.15.5.1" "$SAVE_ENV"
 save_var FUSION_IMAGE_RELEASE          "3860"     "$SAVE_ENV"
 save_var FUSION_NN_PROXY_VERSION       "5.0.0.1"  "$SAVE_ENV"
-save_var LIVEDATA_UI_VERSION           "5.8.0"    "$SAVE_ENV"
+save_var LIVEDATA_UI_VERSION           "5.9.1"    "$SAVE_ENV"
 save_var FUSION_NN_PROXY_IMAGE_RELEASE "3860"     "$SAVE_ENV"
 save_var FUSION_LIVEHIVE_VERSION       "7.1.0.2"  "$SAVE_ENV"
 save_var FUSION_LIVEHIVE_IMAGE_RELEASE "3860"     "$SAVE_ENV"

--- a/docker-compose.common-tmpl.yml
+++ b/docker-compose.common-tmpl.yml
@@ -33,14 +33,12 @@ services:
 
   # LiveData UI
   livedata-ui:
-    image: ${FUS_REGISTRY}/livedata-ui:${LIVEDATA_UI_VERSION}
+    image: wandisco/livedata-ui:${LIVEDATA_UI_VERSION}
     restart: unless-stopped
     networks:
       - fusion
     ports:
       - ${LIVEDATA_UI_PORT}:8081
-    environment:
-      - FUSION_SERVER_HOSTNAMES=${FUSION_SERVER_HOSTNAMES}
     env_file:
       - "${COMMON_ENV}"
     volumes:

--- a/docker-compose.monitoring-tmpl.yml
+++ b/docker-compose.monitoring-tmpl.yml
@@ -19,7 +19,7 @@ version: "3.7"
 
 services:
   nagios:
-    image: wandisco/nagios:4.4.6-v0.10
+    image: wandisco/nagios:4.4.6-v0.11
     restart: unless-stopped
     volumes:
       - nagios-var:/opt/nagios/var
@@ -40,7 +40,7 @@ services:
       - fusion
 
   collectd-host:
-    image: wandisco/collectd:v0.2
+    image: wandisco/collectd:v0.4
     environment:
       - GRAPHITE_HOST=localhost
       - GRAPHITE_PORT=2003
@@ -49,7 +49,7 @@ services:
     network_mode: host
 
   collectd-bridge:
-    image: wandisco/collectd:v0.2
+    image: wandisco/collectd:v0.4
     env_file:
       - "common.env"
     environment:
@@ -73,7 +73,7 @@ services:
       - fusion
 
   grafana:
-    image: wandisco/grafana:7.1.2-v0.3
+    image: wandisco/grafana:7.1.2-v0.6
     restart: unless-stopped
     volumes:
       - grafana-storage:/var/lib/grafana

--- a/docker-compose.sandbox-cdh-vanilla.yml
+++ b/docker-compose.sandbox-cdh-vanilla.yml
@@ -1,0 +1,40 @@
+---
+#################################################################################
+# Copyright (c) 2020 WANdisco
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Apache License, Version 2.0
+#
+################################################################################
+#
+# This docker-compose.yml file will bring up an CDH sandbox vanilla cluster
+
+version: "3.7"
+
+services:
+  sandbox-cdh:
+    image: wandisco/sandbox-cdh-vanilla
+    privileged: true
+    command: ["/sbin/init"]
+    ports:
+      - "7180:7180"
+      - "8889:8889"
+      - "50070:50070"
+      - "50010:50010"
+      - "8081:8081"
+      - "18080:18080"
+    networks:
+      - fusion
+    hostname: sandbox-cdh
+    ulimits:
+      nproc: 800000
+      nofile:
+        soft: 170000
+        hard: 190000
+
+networks:
+  fusion: {}


### PR DESCRIPTION
bump to 5.9.1

DAP-658 - Update databricks plugin version in fusion images

DAP-389 setup-env.sh option to deploy Monitoring Example

DAP-360 Add IHC server port in common.env

DAP-361 update nagios version

DAP-404 Nagios Sample Alert - Java Heap usage

DAP-663 Nagios Sample Alert - License usage and expiry

DAP-666 Create Grafana Sample Graph for Bandwidth usage

DAP-666 update grafana version

Update OneUI image version

DAP-669 Nagios Sample Alert - Fusion Server - Fusion IHC zone connection

DAP-671 Implement fusion snapshot usage from internal registry in DAP

DAP-393 Nagios Sample Alert - ERROR

Update nagios version

DAP-363 Databricks option missing for ADLS2 plugins in setup-env.sh

DAP-392 Grafana Sample Graphs for GSN

Bump new version of nagios

DAP-682 Installing LDM + OneUI package fails because of inaccessible HDP mirror

DAP-649 Build GA Fusion 2.15.5 into docker image once released

DAP-691 new sandbox image

Bump new nagios image version

DAP-696 Create setup.env script option for LDM +UI

New sandbox-hdp image version

DAP-710 Create docker-compose file for LDM

DAP-697 Create github action for standalone github repo

DAP-713 Rename fusion-oneui-server Docker service to livedata-ui

Update LDM_SERVERS variable

from http://livedata-migrator:18080 to livedata-migrator:18080

Python-dotenv errors when using monitoring option -m

DAP-753 Ci Automation - deploy hdp-sandbox-vanilla into own repo

DAP-768 update hdp vanilla image version

DAP-662 Bump new nagios version

Change repo for livedata-ui to public

Bump grafana image version

DAP-760 grafana fusion error/fatal logs graph

DAP-762 new grafana sample graphs

Update docker-compose.sandbox-hdp-vanilla.yml

DAP-745 CDH vanilla image